### PR TITLE
Fixed build.bat and patchdol.bat

### DIFF
--- a/ports/pal/build.bat
+++ b/ports/pal/build.bat
@@ -2,7 +2,7 @@ C:\devkitPro\devkitPPC\bin\powerpc-eabi-gcc.exe %1 -S -o %~n1.s -O1 -std=c99
 C:\devkitPro\devkitPPC\bin\powerpc-eabi-gcc.exe %1 -c -o %~n1.o -O1 -std=c99
 if ERRORLEVEL 1 pause
 if ERRORLEVEL 1 exit
-C:\devkitPro\devkitPPC\bin\powerpc-eabi-ld.exe -Os -T linkerEU -T smsFuncsEU -o obj_%~n1.o %~n1.o -Map %~n1.map
+C:\devkitPro\devkitPPC\bin\powerpc-eabi-ld.exe -Os -T linker -T smsFuncs -o obj_%~n1.o %~n1.o -Map %~n1.map
 if ERRORLEVEL 1 pause
 if ERRORLEVEL 1 exit
 C:\devkitPro\devkitPPC\bin\powerpc-eabi-objdump.exe obj_%~n1.o --full-content

--- a/ports/pal/patchdol.bat
+++ b/ports/pal/patchdol.bat
@@ -2,7 +2,7 @@ C:\devkitPro\devkitPPC\bin\powerpc-eabi-gcc.exe %1 -S -o %~n1.s -O1 -std=c99 -w
 C:\devkitPro\devkitPPC\bin\powerpc-eabi-gcc.exe %1 -c -o %~n1.o -O1 -std=c99 -w
 if ERRORLEVEL 1 pause
 if ERRORLEVEL 1 exit
-C:\devkitPro\devkitPPC\bin\powerpc-eabi-ld.exe -Os -T dollinkerEU -T smsFuncsEU -o obj_%~n1.o %~n1.o -Map %~n1.map
+C:\devkitPro\devkitPPC\bin\powerpc-eabi-ld.exe -Os -T dollinker -T smsFuncs -o obj_%~n1.o %~n1.o -Map %~n1.map
 if ERRORLEVEL 1 pause
 if ERRORLEVEL 1 exit
 C:\devkitPro\devkitPPC\bin\powerpc-eabi-objdump.exe obj_%~n1.o --full-content


### PR DESCRIPTION
I made the port in the root folder by appending “EU” to every file name, so build.bat and patchdol.bat referenced linkerEU, dollinkerEU and smsFuncsEU, which don’t exist anymore.